### PR TITLE
1.0.4 (fix) add missing babel dep

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.4
+- manifest: add missing babel dep
+
 # 1.0.3
 - docs: create/update
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy-exec",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Execution logic for bfx-hf-strategy",
   "main": "./index.js",
   "directories": {
@@ -37,6 +37,7 @@
     "BTC"
   ],
   "dependencies": {
+    "babel": "^6.23.0",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-regenerator": "^6.24.1",


### PR DESCRIPTION
### Description:
Adds `babel` to manifest

### Fixes:
- [x] `postinstall` step

### PR status:
- [x] Version bumped
- [x] Change-log updated
