### PR TITLE
Double every order fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ const exec = async (strategy = {}, wsManager = {}, rest = {}, args = {}) => {
   const { symbol, tf, includeTrades, seedCandleCount = 5000 } = args
   const candleKey = `trade:${tf}:${symbol}`
   const messages = []
+
   let strategyState = strategy
   let lastCandle = null
+  let lastTrade = null
   let processing = false
 
   debug('seeding with last ~%d candles...', seedCandleCount)
@@ -105,9 +107,15 @@ const exec = async (strategy = {}, wsManager = {}, rest = {}, args = {}) => {
 
     switch (type) {
       case 'trade': {
+        if (lastTrade && lastTrade.id >= data.id) {
+          break
+        }
+
         data.symbol = symbol
         debug('recv trade: %j', data)
         strategyState = await onTrade(strategyState, data)
+        lastTrade = data
+        
         break
       }
 

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ const exec = async (strategy = {}, wsManager = {}, rest = {}, args = {}, conn) =
 
   const processMessages = async () => {
     processing = true
-    
+
     while (!_isEmpty(messages)) {
       const [msg] = messages.splice(0, 1)
 
@@ -170,11 +170,11 @@ const exec = async (strategy = {}, wsManager = {}, rest = {}, args = {}, conn) =
     if (candles.length > 1) { // seeding happens at start via RESTv2
       return
     }
-    
+
     const [candle] = candles
     candle.symbol = symbol
     candle.tf = tf
-    
+
     _debouncedEnqueue('candle', candle)
   })
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "bfx-api-node-core": "^1.5.5",
     "bfx-api-node-util": "^1.0.2",
-    "bfx-hf-util": "^1.0.1",
+    "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util.git#v1.0.12",
     "lodash": "^4.17.10",
     "promise-throttle": "^1.0.0"
   },


### PR DESCRIPTION
### Description:
The candle subscription event emits both the old and new candle data simultaneously on each ticl, causing the `priceUpdate` function to be called twice and hence resulting in the order to be placed twice if matched. So, a debounce function was introduced to only use the most recent candle data.

### New features:
- [x] emit error events

### Fixes:
- [x] ignore old trades
- [x] added debounce function to handle simulataneous candle data

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
