### PR TITLE
Wait candle to close

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const PromiseThrottle = require('promise-throttle')
 const debug = require('debug')('bfx:hf:strategy-exec')
 
 const {
-  onSeedCandle, onCandle, onCandleUpdate, onTrade, closeOpenPositions
+  onSeedCandle, onCandle, onTrade, closeOpenPositions
 } = require('bfx-hf-strategy')
 
 const EventEmitter = require('events')
@@ -201,13 +201,13 @@ class LiveStrategyExecution extends EventEmitter {
    * @private
    */
   async _processCandleData (data) {
-    if (this.lastCandle === null || this.lastCandle.mts < data.mts) {
-      debug('recv candle %j', data)
-      this.strategyState = await onCandle(this.strategyState, data)
+    if (this.lastCandle === null || this.lastCandle.mts === data.mts) {
+      // in case of first candle received or candle update event
       this.lastCandle = data
-    } else if (this.lastCandle.mts === data.mts) {
-      debug('updated candle %j', data)
-      this.strategyState = await onCandleUpdate(this.strategyState, data)
+    } else if (this.lastCandle.mts < data.mts) {
+      debug('recv candle %j', data)
+      this.strategyState = await onCandle(this.strategyState, this.lastCandle) // send closed candle data
+      this.lastCandle = data // save new candle data
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const _max = require('lodash/max')
 const _isNil = require('lodash/isNil')
 const _isEmpty = require('lodash/isEmpty')
 const _reverse = require('lodash/reverse')
-const _debounce = require('lodash/debounce')
 const _isFunction = require('lodash/isFunction')
 
 const { candleWidth } = require('bfx-hf-util')
@@ -23,7 +22,6 @@ const {
 const EventEmitter = require('events')
 
 const CANDLE_FETCH_LIMIT = 1000
-const DEBOUNCE_PERIOD_MS = 100
 const pt = new PromiseThrottle({
   requestsPerSecond: 10.0 / 60.0, // taken from docs
   promiseImplementation: Promise
@@ -55,8 +53,6 @@ class LiveStrategyExecution extends EventEmitter {
     this.lastTrade = null
     this.processing = false
     this.messages = []
-
-    this._debouncedEnqueue = _debounce(this._enqueueMessage.bind(this), DEBOUNCE_PERIOD_MS)
 
     this._registerManagerEventListeners()
   }
@@ -91,7 +87,7 @@ class LiveStrategyExecution extends EventEmitter {
       candle.symbol = symbol
       candle.tf = tf
 
-      this._debouncedEnqueue('candle', candle)
+      this._enqueueMessage('candle', candle)
     })
   }
 
@@ -274,8 +270,6 @@ class LiveStrategyExecution extends EventEmitter {
     if (this.strategyState.margin) {
       this.strategyState = await closeOpenPositions(this.strategyState)
     }
-
-    this._debouncedEnqueue.cancel()
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -150,8 +150,6 @@ class LiveStrategyExecution extends EventEmitter {
    * @private
    */
   _enqueueMessage (type, data) {
-    debug('enqueue %s', type)
-
     this.messages.push({ type, data })
 
     if (!this.processing) {
@@ -202,6 +200,7 @@ class LiveStrategyExecution extends EventEmitter {
       this.lastCandle = data
     } else if (this.lastCandle.mts < data.mts) {
       debug('recv candle %j', data)
+      debug('closed candle %j', this.lastCandle)
       this.strategyState = await onCandle(this.strategyState, this.lastCandle) // send closed candle data
       this.lastCandle = data // save new candle data
     }


### PR DESCRIPTION
### Task: 
https://app.asana.com/0/1201849173362898/1201893364797923

### Description:
Currently, the execution is based on each price update. This PR eliminates that and waits for the candles to close first before checking the conditions of the strategy.
Also, debounced queuing is removed since we don't process outdated candle data and omit them anyway.

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
