### PR TITLE
stop processing messages after stopped

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ class LiveStrategyExecution extends EventEmitter {
     this.lastCandle = null
     this.lastTrade = null
     this.processing = false
+    this.stopped = false
     this.messages = []
 
     this._registerManagerEventListeners()
@@ -150,6 +151,11 @@ class LiveStrategyExecution extends EventEmitter {
    * @private
    */
   _enqueueMessage (type, data) {
+    debug('typppeeee %s, %s', type, this.stopped)
+    if (this.stopped) {
+      return
+    }
+
     this.messages.push({ type, data })
 
     if (!this.processing) {
@@ -269,6 +275,8 @@ class LiveStrategyExecution extends EventEmitter {
     if (this.strategyState.margin) {
       this.strategyState = await closeOpenPositions(this.strategyState)
     }
+
+    this.stopped = true
   }
 
   /**


### PR DESCRIPTION
### Description:
Add stopped variable to not process after the execution is stopped.

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
