### PR TITLE
use trade data for price feed

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,10 +116,13 @@ class LiveStrategyExecution extends EventEmitter {
         return
       }
 
-      console.log(trades)
-
       if (includeTrades) {
         this._enqueueMessage('trade', trades)
+      }
+
+      if (trades.mts > this.lastPriceFeedUpdate) {
+        this.priceFeed.update(trades.price, trades.mts)
+        this.lastPriceFeedUpdate = trades.mts
       }
     })
 
@@ -324,11 +327,6 @@ class LiveStrategyExecution extends EventEmitter {
       return
     }
 
-    if (data.mts > this.lastPriceFeedUpdate) {
-      this.priceFeed.update(data.price)
-      this.lastPriceFeedUpdate = data.mts
-    }
-
     const { symbol } = this.strategyState
     data.symbol = symbol
     debug('recv trade: %j', data)
@@ -343,7 +341,7 @@ class LiveStrategyExecution extends EventEmitter {
    */
   async _processCandleData (data) {
     if (data.mts > this.lastPriceFeedUpdate) {
-      this.priceFeed.update(data[this.candlePrice])
+      this.priceFeed.update(data[this.candlePrice], data.mts)
       this.lastPriceFeedUpdate = data.mts
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy-exec",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Execution logic for bfx-hf-strategy",
   "main": "./index.js",
   "directories": {


### PR DESCRIPTION
Now we always subscribe to trade data to update the price feed to track safety metrics like stop loss and drawdowns.
This doesn't affect the strategy data input.